### PR TITLE
Added line highlighting calls deadline

### DIFF
--- a/conf2016.md
+++ b/conf2016.md
@@ -46,7 +46,9 @@ title: RSE 2016 | Home
 
 **The RSE Conference (15-16 September) is the first conference to focus exclusively on the issues that affect people who write and use software in research. It is not a standard academic conference! We welcome researchers, but we also want to hear from people who may not typically attend conferences. It’s a community conference: get involved and help us build the RSE Community.**
 
-From running a workshop, sharing your ideas or simply attending, there are many ways in which you can participate. We want to hear from you about the new technologies and techniques that help you in your work. We want your opinions on what will make the conference even more useful. And, of course, we want you to attend!
+**Call for talks and workshops open now – [submit your proposal] (conf2016_calls) by 10th June**
+
+From running a workshop to sharing your ideas or simply attending, there are many ways in which you can participate. We want to hear from you about the new technologies and techniques that help you in your work. We want your opinions on what will make the conference even more useful. And, of course, we want you to attend!
 
 We’ve described the many different ways you can participate below. Take a look, and [get in touch](mailto:info@rse.ac.uk) if you’d like more information.
 


### PR DESCRIPTION
Suggested change to highlight the calls deadline on front page for the next two weeks. Need to remove after 10th June